### PR TITLE
Removed ./openapi/openapi.yaml

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -4,5 +4,5 @@ echo "Building API Docs"
 
 # Bundle the API docs and build the index.html
 
-npx @redocly/cli bundle ./openapi/openapi.yaml -o sfgoa3.yaml && \
+npx @redocly/cli bundle -o sfgoa3.yaml && \
 npx @redocly/cli build-docs sfgoa3.yaml -o index.html


### PR DESCRIPTION
## What/Why/How?

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

## Summary by Sourcery

Chores:
- Remove the reference to './openapi/openapi.yaml' in the make.sh script.